### PR TITLE
Move preprocessor imports into function body

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -1,6 +1,3 @@
-import numpy as np
-import xarray as xr
-
 from pangeo_forge_recipes.patterns import ConcatDim, FilePattern, MergeDim
 from pangeo_forge_recipes.recipes.xarray_zarr import XarrayZarrRecipe
 
@@ -33,6 +30,9 @@ pattern = FilePattern(
 
 # clean up the dataset so that lat and lon are included as dimension coordinates
 def postproc(ds):
+    import numpy as np
+    import xarray as xr
+    
     variable = [var for var in ds.data_vars.keys() if 'bound' not in var][0]
     coords = [key for key in ds.coords.keys()]
     coord_d = {}


### PR DESCRIPTION
Based on recent experience with this issue, e.g. in https://github.com/pangeo-forge/staged-recipes/pull/188#issuecomment-1261563283, it seems that, among any other bugs to fix on this recipe, we will at the minimum need to move these imports inside the function body.