### PR TITLE
Upgrade to recipes 0.9.4, and use kerchunk to open inputs

### DIFF
--- a/feedstock/meta.yaml
+++ b/feedstock/meta.yaml
@@ -1,6 +1,6 @@
 title: 'C-iTRACE-tracers'
 description: 'Coarse resolution, ocean-only simulation from 22ka to present using the isotope-enabled ocean component of CESM1'
-pangeo_forge_version: '0.9.3'
+pangeo_forge_version: '0.9.4'
 pangeo_notebook_version: '2022.06.02'
 recipes:
   - id: citrace_tracer

--- a/feedstock/meta.yaml
+++ b/feedstock/meta.yaml
@@ -1,6 +1,6 @@
 title: 'C-iTRACE-tracers'
 description: 'Coarse resolution, ocean-only simulation from 22ka to present using the isotope-enabled ocean component of CESM1'
-pangeo_forge_version: '0.9.0'
+pangeo_forge_version: '0.9.3'
 pangeo_notebook_version: '2022.06.02'
 recipes:
   - id: citrace_tracer

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -84,7 +84,7 @@ recipe = XarrayZarrRecipe(
     pattern,
     inputs_per_chunk=1,
     consolidate_zarr=True,
-    subset_inputs={'time': 120},
+    open_input_with_kerchunk=True,
     target_chunks={'time': 1},
     process_chunk=postproc,
     xarray_open_kwargs={'decode_coords': True, 'use_cftime': True, 'decode_times': True},


### PR DESCRIPTION
@jordanplanders https://github.com/pangeo-forge/pangeo-forge-recipes/pull/383 was merged this week, so upgrading this feedstock's required pangeo-forge-recipes version may likely resolve the root issue #3 we've been fighting all along. I'll run a test from this PR to see if that's the case. 🤞  